### PR TITLE
Fix incompatibility with Xcode 7.3

### DIFF
--- a/CrashSymbal/JFWSymbolicateViewController.m
+++ b/CrashSymbal/JFWSymbolicateViewController.m
@@ -179,6 +179,21 @@
 			NSString *developerDir = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"Contents/Developer"];
 			
 			NSTask *symbolicationTask = [[NSTask alloc] init];
+						NSString *symbolicatecrashPath = [[NSBundle bundleWithIdentifier:@"com.apple.dt.DVTFoundation"] pathForResource:@"symbolicatecrash" ofType:nil];
+
+			if (symbolicatecrashPath == nil) {
+				// Try an older style bundle identifier
+				symbolicatecrashPath = [[NSBundle bundleWithIdentifier:@"com.apple.DTDeviceKitBase"] pathForResource:@"symbolicatecrash" ofType:nil];
+			}
+
+			if (symbolicatecrashPath == nil) {
+				NSLog(@"CrashSymbal: cannot locate 'symbolicatecrash' in this version of Xcode");
+
+				return;
+			}
+
+			NSLog(@"CrashSymbal:symbolicatecrash: %@", symbolicatecrashPath);
+
 			[symbolicationTask setLaunchPath:[[NSBundle bundleWithIdentifier:@"com.apple.DTDeviceKitBase"] pathForResource:@"symbolicatecrash" ofType:nil]];
 			[symbolicationTask setEnvironment:@{@"DEVELOPER_DIR": developerDir}];
 			[symbolicationTask setArguments:@[@"-v", [self selectedPath]]];


### PR DESCRIPTION
The CFBundleIdentifier for DVTFoundation framework changed causing CrashSymbal to crash Xcode when it couldn't find 'symbolicatecrash'
